### PR TITLE
Add initial counter state to show resumed training from checkpoints

### DIFF
--- a/keras_tqdm/tqdm_callback.py
+++ b/keras_tqdm/tqdm_callback.py
@@ -16,7 +16,8 @@ class TQDMCallback(Callback):
                  leave_outer=True,
                  show_inner=True,
                  show_outer=True,
-                 output_file=stderr):
+                 output_file=stderr,
+                 initial = 0):
         """
         Construct a callback that will create and update progress bars.
 
@@ -30,6 +31,7 @@ class TQDMCallback(Callback):
         :param show_inner: False to hide inner bars
         :param show_outer: False to hide outer bar
         :param output_file: output file (default sys.stderr)
+        :param initial: Initial counter state 
         """
         self.outer_description = outer_description
         self.inner_description_initial = inner_description_initial
@@ -46,16 +48,18 @@ class TQDMCallback(Callback):
         self.epoch = None
         self.running_logs = None
         self.inner_count = None
+        self.initial = initial
 
-    def tqdm(self, desc, total, leave):
+    def tqdm(self, desc, total, leave, initial=0):
         """
         Extension point. Override to provide custom options to tqdm initializer.
         :param desc: Description string
         :param total: Total number of updates
         :param leave: Leave progress bar when done
+        :param initial: Initial counter state
         :return: new progress bar
         """
-        return tqdm(desc=desc, total=total, leave=leave, file=self.output_file)
+        return tqdm(desc=desc, total=total, leave=leave, file=self.output_file, initial=initial)
 
     def build_tqdm_outer(self, desc, total):
         """
@@ -64,7 +68,7 @@ class TQDMCallback(Callback):
         :param total: Number of epochs
         :return: new progress bar
         """
-        return self.tqdm(desc=desc, total=total, leave=self.leave_outer)
+        return self.tqdm(desc=desc, total=total, leave=self.leave_outer, initial=self.initial)
 
     def build_tqdm_inner(self, desc, total):
         """

--- a/keras_tqdm/tqdm_notebook_callback.py
+++ b/keras_tqdm/tqdm_notebook_callback.py
@@ -12,7 +12,8 @@ class TQDMNotebookCallback(TQDMCallback):
                  separator=", ",
                  leave_inner=False,
                  leave_outer=True,
-                 output_file=sys.stderr, **kwargs):
+                 output_file=sys.stderr,
+                 initial=0, **kwargs):
         super(TQDMNotebookCallback, self).__init__(outer_description=outer_description,
                                                    inner_description_initial=inner_description_initial,
                                                    inner_description_update=inner_description_update,
@@ -20,14 +21,16 @@ class TQDMNotebookCallback(TQDMCallback):
                                                    separator=separator,
                                                    leave_inner=leave_inner,
                                                    leave_outer=leave_outer,
-                                                   output_file=output_file, **kwargs)
+                                                   output_file=output_file,
+                                                   initial=initial, **kwargs)
 
-    def tqdm(self, desc, total, leave):
+    def tqdm(self, desc, total, leave, initial=0):
         """
         Extension point. Override to provide custom options to tqdm_notebook initializer.
         :param desc: Description string
         :param total: Total number of updates
         :param leave: Leave progress bar when done
         :return: new progress bar
+        :param initial: Initial counter state
         """
-        return tqdm_notebook(desc=desc, total=total, leave=leave)
+        return tqdm_notebook(desc=desc, total=total, leave=leave, initial=initial)


### PR DESCRIPTION
This is useful when resuming training from a checkpoint at a specific epoch. The starting epoch can now be given to tqdm and the progress bar of the outer loop shows the correct percentage.