### PR TITLE
Fix exception when fit is fed by tf.data.Dataset

### DIFF
--- a/keras_tqdm/tqdm_callback.py
+++ b/keras_tqdm/tqdm_callback.py
@@ -83,9 +83,9 @@ class TQDMCallback(Callback):
         self.epoch = epoch
         desc = self.inner_description_initial.format(epoch=self.epoch)
         self.mode = 0  # samples
-        if 'samples' in self.params:
+        if self.params.get('samples', None):
             self.inner_total = self.params['samples']
-        elif 'nb_sample' in self.params:
+        elif self.params.get('nb_sample', None):
             self.inner_total = self.params['nb_sample']
         else:
             self.mode = 1  # steps


### PR DESCRIPTION
If `model.fit()` is called with a `tf.data.Dataset`, the `self.params` dictionary will contain `{'samples': None}` which later breaks (on line 120). Checking if the value is falsey should be enough to aim at the correct mode as these values don't make sense as 0 either.