### PR TITLE
Fix incompatibility with tf.data.Dataset

### DIFF
--- a/keras_tqdm/tqdm_callback.py
+++ b/keras_tqdm/tqdm_callback.py
@@ -83,9 +83,9 @@ class TQDMCallback(Callback):
         self.epoch = epoch
         desc = self.inner_description_initial.format(epoch=self.epoch)
         self.mode = 0  # samples
-        if 'samples' in self.params:
+        if 'samples' in self.params and self.params['samples'] is not None:
             self.inner_total = self.params['samples']
-        elif 'nb_sample' in self.params:
+        elif 'nb_sample' in self.params and self.params['nb_samples'] is not None:
             self.inner_total = self.params['nb_sample']
         else:
             self.mode = 1  # steps


### PR DESCRIPTION
When you try to use this callback with a dataset, it errors out later because `samples` has a value of `None`.  However, there is a value for `steps`, so the else does take care of the dataset case. This change assures that the dataset case is directed to the else.

The other [PR](https://github.com/bstriner/keras-tqdm/pull/26) opened for this bug does not work.