### PR TITLE
keras API change

### DIFF
--- a/keras_tqdm/tqdm_callback.py
+++ b/keras_tqdm/tqdm_callback.py
@@ -111,6 +111,12 @@ class TQDMCallback(Callback):
     def on_batch_begin(self, batch, logs={}):
         pass
 
+    def on_train_batch_begin(self, batch, logs={}):
+        pass
+
+    def on_train_batch_end(self, batch, logs={}):
+        self.on_batch_end(batch, logs)
+
     def on_batch_end(self, batch, logs={}):
         if self.mode == 0:
             update = logs['size']


### PR DESCRIPTION
keras callbacks has a new API. `on_train_batch_begin` and `on_train_batch_end` are the new names for `on_batch_begin` and `on_batch_end`.

Refer to:https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/callbacks.py#L175