### PR TITLE
changed from keras to tensorflow.keras

### DIFF
--- a/keras_tqdm/tqdm_callback.py
+++ b/keras_tqdm/tqdm_callback.py
@@ -2,7 +2,7 @@ from sys import stderr
 
 import numpy as np
 import six
-from keras.callbacks import Callback
+from tensorflow.keras.callbacks import Callback
 from tqdm import tqdm
 
 


### PR DESCRIPTION
This avoids the "Using Tensorflow as backend" message.