### PR TITLE
added support for tensorflow>=2.1

### DIFF
--- a/keras_tqdm/tqdm_callback.py
+++ b/keras_tqdm/tqdm_callback.py
@@ -137,16 +137,16 @@ class TQDMCallback(Callback):
             self.tqdm_outer.close()
 
     def append_logs(self, logs):
-        metrics = self.params['metrics']
+        metrics = logs
         for metric, value in six.iteritems(logs):
             if metric in metrics:
                 if metric in self.running_logs:
-                    self.running_logs[metric].append(value[()])
+                    self.running_logs[metric].append(value)
                 else:
-                    self.running_logs[metric] = [value[()]]
+                    self.running_logs[metric] = [value]
 
     def format_metrics(self, logs):
-        metrics = self.params['metrics']
+        metrics = logs
         strings = [self.metric_format.format(name=metric, value=np.mean(logs[metric], axis=None)) for metric in metrics
                    if
                    metric in logs]


### PR DESCRIPTION
Fixed error "KeyError: 'metrics'" when running on tensorflow versions 2.1+. self.params dict no longer has the key "metrics". instead, metrics are in logs. 